### PR TITLE
Fix gradle build error

### DIFF
--- a/src/main/help/help/topics/ntrghidra/help.html
+++ b/src/main/help/help/topics/ntrghidra/help.html
@@ -10,7 +10,7 @@
     <META name="ProgId" content="FrontPage.Editor.Document">
 
     <TITLE>Skeleton Help File for a Module</TITLE>
-    <LINK rel="stylesheet" type="text/css" href="../../shared/Frontpage.css">
+    <LINK rel="stylesheet" type="text/css" href="help/shared/DefaultStyle.css">
   </HEAD>
 
   <BODY>


### PR DESCRIPTION
When attempting to build this plugin for Ghidra 10.3.x or 10.4.x in github actions, the gradle build step reports that a reference to a `DefaultStyle.css` file is missing from `help.html`.
The build seems to work after I update the html stylesheet to point to it instead of `Frontpage.css`. I don't know if this is the right way to fix it, I just guessed based on the error message. But it seems to work as expected so I figured I'd file a PR.