### PR TITLE
Upgrade to Ghidra 11.0.1 + build steps

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,11 +4,6 @@
 	<classpathentry kind="src" path="src/main/help"/>
 	<classpathentry kind="src" path="src/main/resources"/>
 	<classpathentry kind="src" path="ghidra_scripts"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/GhidraDev_jdk-18.0.1.1">
-		<attributes>
-			<attribute name="module" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="lib" path="Ghidra/Ghidra/Processors/68000/lib/68000.jar" sourcepath="Ghidra/Ghidra/Processors/68000/lib/68000-src.zip">
 		<attributes>
@@ -41,16 +36,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="Ghidra/Ghidra/Features/Base/lib/Base.jar" sourcepath="Ghidra/Ghidra/Features/Base/lib/Base-src.zip">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="D:/Tools/Ghidra/ghidra_10.2.2_PUBLIC/Ghidra/Features/Base/lib/biz.aQute.bndlib-6.2.0.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="D:/Tools/Ghidra/ghidra_10.2.2_PUBLIC/Ghidra/Features/Base/lib/org.apache.felix.framework-7.0.3.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
 		</attributes>
@@ -110,16 +95,6 @@
 			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="D:/Tools/Ghidra/ghidra_10.2.2_PUBLIC/Ghidra/Debug/Framework-Debugging/lib/jna-5.4.0.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="D:/Tools/Ghidra/ghidra_10.2.2_PUBLIC/Ghidra/Debug/Framework-Debugging/lib/jna-platform-5.4.0.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="lib" path="Ghidra/Ghidra/Debug/Debugger-agent-dbgmodel/lib/Debugger-agent-dbgmodel.jar" sourcepath="Ghidra/Ghidra/Debug/Debugger-agent-dbgmodel/lib/Debugger-agent-dbgmodel-src.zip">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
@@ -136,11 +111,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="Ghidra/Ghidra/Debug/Debugger-gadp/lib/Debugger-gadp.jar" sourcepath="Ghidra/Ghidra/Debug/Debugger-gadp/lib/Debugger-gadp-src.zip">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="Ghidra/Ghidra/Debug/Debugger-gadp/lib/protobuf-java-3.17.3.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
 		</attributes>
@@ -165,57 +135,12 @@
 			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="D:/Tools/Ghidra/ghidra_10.2.2_PUBLIC/Ghidra/Framework/Help/lib/javahelp-2.0.05.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="D:/Tools/Ghidra/ghidra_10.2.2_PUBLIC/Ghidra/Framework/Help/lib/timingframework-1.0.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="Ghidra/Ghidra/Features/FileFormats/lib/asm-debug-all-4.1.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="lib" path="Ghidra/Ghidra/Features/FileFormats/lib/AXMLPrinter2.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="Ghidra/Ghidra/Features/FileFormats/lib/baksmali-1.4.0.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="lib" path="Ghidra/Ghidra/Framework/Generic/lib/bcprov-jdk15on-1.69.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="Ghidra/Ghidra/Features/FileFormats/lib/dex-ir-2.0.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="Ghidra/Ghidra/Features/FileFormats/lib/dex-reader-2.0.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="Ghidra/Ghidra/Features/FileFormats/lib/dex-reader-api-2.0.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="Ghidra/Ghidra/Features/FileFormats/lib/dex-translator-2.0.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="Ghidra/Ghidra/Features/FileFormats/lib/dexlib-1.4.0.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
 		</attributes>
@@ -235,17 +160,7 @@
 			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="Ghidra/Ghidra/Features/FileFormats/lib/util-1.4.0.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="lib" path="Ghidra/Ghidra/Framework/FileSystem/lib/FileSystem.jar" sourcepath="Ghidra/Ghidra/Framework/FileSystem/lib/FileSystem-src.zip">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="D:/Tools/Ghidra/ghidra_10.2.2_PUBLIC/Ghidra/Framework/FileSystem/lib/FileSystem.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
 		</attributes>
@@ -285,32 +200,7 @@
 			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="D:/Tools/Ghidra/ghidra_10.2.2_PUBLIC/Ghidra/Features/GhidraServer/data/yajsw-stable-13.05/lib/core/commons/commons-io-2.11.0.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="D:/Tools/Ghidra/ghidra_10.2.2_PUBLIC/Ghidra/Features/GhidraServer/data/yajsw-stable-13.05/lib/core/commons/commons-lang3-3.8.1.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="D:/Tools/Ghidra/ghidra_10.2.2_PUBLIC/Ghidra/Features/GhidraServer/data/yajsw-stable-13.05/lib/core/commons/commons-text-1.10.0.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="lib" path="Ghidra/Ghidra/Framework/Generic/lib/Generic.jar" sourcepath="Ghidra/Ghidra/Framework/Generic/lib/Generic-src.zip">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="D:/Tools/Ghidra/ghidra_10.2.2_PUBLIC/Ghidra/Framework/Generic/lib/gson-2.9.0.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="Ghidra/Ghidra/Framework/Generic/lib/guava-19.0.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
 		</attributes>
@@ -400,16 +290,6 @@
 			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="Ghidra/Ghidra/Features/GraphServices/lib/jungrapht-layout-1.3.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="Ghidra/Ghidra/Features/GraphServices/lib/jungrapht-visualization-1.3.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="lib" path="Ghidra/Ghidra/Processors/HCS12/lib/HCS12.jar" sourcepath="Ghidra/Ghidra/Processors/HCS12/lib/HCS12-src.zip">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
@@ -470,11 +350,6 @@
 			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="D:/Tools/Ghidra/ghidra_10.2.2_PUBLIC/Ghidra/Framework/Project/lib/commons-compress-1.21.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="lib" path="Ghidra/Ghidra/Framework/Project/lib/Project.jar" sourcepath="Ghidra/Ghidra/Framework/Project/lib/Project-src.zip">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
@@ -486,11 +361,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="Ghidra/Ghidra/Configurations/Public_Release/lib/Public_Release.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="D:/Tools/Ghidra/ghidra_10.2.2_PUBLIC/Ghidra/Features/Python/lib/jython-standalone-2.7.3.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
 		</attributes>
@@ -578,6 +448,756 @@
 	<classpathentry kind="lib" path="Ghidra/Ghidra/Processors/x86/lib/x86.jar" sourcepath="Ghidra/Ghidra/Processors/x86/lib/x86-src.zip">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/NTRGhidra/Ghidra/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/java-17-openjdk-amd64">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/68000/lib/68000.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/68000/lib/68000-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/8051/lib/8051.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/AARCH64/lib/AARCH64.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/AARCH64/lib/AARCH64-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/ARM/lib/ARM.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/ARM/lib/ARM-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/AnnotationValidator/lib/AnnotationValidator.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/AnnotationValidator/lib/AnnotationValidator-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/Atmel/lib/Atmel.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/Atmel/lib/Atmel-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/BSim/lib/log4j-jcl-2.16.0.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/BSim/lib/commons-logging-1.2.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/BSim/lib/postgresql-42.6.0.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/BSim/lib/json-simple-1.1.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/BSim/lib/h2-2.2.220.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/BSim/lib/BSim.jar" sourcepath="/opt/ghidra11/Ghidra/Features/BSim/lib/BSim-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/BSim/lib/commons-dbcp2-2.9.0.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/BSim/lib/commons-pool2-2.11.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/BSimFeatureVisualizer/lib/BSimFeatureVisualizer.jar" sourcepath="/opt/ghidra11/Ghidra/Features/BSimFeatureVisualizer/lib/BSimFeatureVisualizer-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/Base/lib/org.apache.felix.framework-7.0.3.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/Base/lib/slf4j-nop-1.7.25.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/Base/lib/biz.aQute.bnd.util-6.2.0.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/Base/lib/Base.jar" sourcepath="/opt/ghidra11/Ghidra/Features/Base/lib/Base-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/Base/lib/org.osgi.util.promise-1.2.0.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/Base/lib/slf4j-api-1.7.25.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/Base/lib/biz.aQute.bndlib-6.2.0.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/Base/lib/phidias-0.3.7.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/BytePatterns/lib/BytePatterns.jar" sourcepath="/opt/ghidra11/Ghidra/Features/BytePatterns/lib/BytePatterns-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/ByteViewer/lib/ByteViewer.jar" sourcepath="/opt/ghidra11/Ghidra/Features/ByteViewer/lib/ByteViewer-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/CodeCompare/lib/CodeCompare.jar" sourcepath="/opt/ghidra11/Ghidra/Features/CodeCompare/lib/CodeCompare-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/DATA/lib/DATA.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/DATA/lib/DATA-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/DB/lib/DB.jar" sourcepath="/opt/ghidra11/Ghidra/Framework/DB/lib/DB-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/Dalvik/lib/Dalvik.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/Dalvik/lib/Dalvik-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/DebugUtils/lib/DebugUtils.jar" sourcepath="/opt/ghidra11/Ghidra/Features/DebugUtils/lib/DebugUtils-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Debugger/lib/Debugger.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/Debugger/lib/Debugger-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Debugger-agent-dbgeng/lib/Debugger-agent-dbgeng.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/Debugger-agent-dbgeng/lib/Debugger-agent-dbgeng-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Debugger-agent-dbgmodel/lib/Debugger-agent-dbgmodel.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/Debugger-agent-dbgmodel/lib/Debugger-agent-dbgmodel-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Debugger-agent-dbgmodel-traceloader/lib/Debugger-agent-dbgmodel-traceloader.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Debugger-agent-frida/lib/Debugger-agent-frida.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/Debugger-agent-frida/lib/Debugger-agent-frida-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Debugger-agent-gdb/lib/Debugger-agent-gdb.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/Debugger-agent-gdb/lib/Debugger-agent-gdb-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Debugger-agent-lldb/lib/Debugger-agent-lldb.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/Debugger-agent-lldb/lib/Debugger-agent-lldb-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Debugger-api/lib/Debugger-api.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/Debugger-api/lib/Debugger-api-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Debugger-gadp/lib/Debugger-gadp.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/Debugger-gadp/lib/Debugger-gadp-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Debugger-isf/lib/Debugger-isf.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/Debugger-isf/lib/Debugger-isf-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Debugger-jpda/lib/Debugger-jpda.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/Debugger-jpda/lib/Debugger-jpda-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Debugger-rmi-trace/lib/Debugger-rmi-trace.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/Debugger-rmi-trace/lib/Debugger-rmi-trace-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Debugger-swig-lldb/lib/Debugger-swig-lldb.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/Debugger-swig-lldb/lib/Debugger-swig-lldb-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/Decompiler/lib/Decompiler.jar" sourcepath="/opt/ghidra11/Ghidra/Features/Decompiler/lib/Decompiler-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/DecompilerDependent/lib/DecompilerDependent.jar" sourcepath="/opt/ghidra11/Ghidra/Features/DecompilerDependent/lib/DecompilerDependent-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Docking/lib/Docking.jar" sourcepath="/opt/ghidra11/Ghidra/Framework/Docking/lib/Docking-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Emulation/lib/Emulation.jar" sourcepath="/opt/ghidra11/Ghidra/Framework/Emulation/lib/Emulation-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/FileFormats/lib/util-2.5.2.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/FileFormats/lib/dexlib2-2.5.2.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/FileFormats/lib/FileFormats.jar" sourcepath="/opt/ghidra11/Ghidra/Features/FileFormats/lib/FileFormats-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/FileFormats/lib/AXMLPrinter2.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/FileFormats/lib/dex-reader-api-2.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/FileFormats/lib/sevenzipjbinding-all-platforms-16.02-2.01.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/FileFormats/lib/dex-ir-2.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/FileFormats/lib/sevenzipjbinding-16.02-2.01.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/FileFormats/lib/dex-translator-2.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/FileFormats/lib/asm-debug-all-5.0.3.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/FileFormats/lib/dex-reader-2.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/FileFormats/lib/baksmali-2.5.2.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/FileSystem/lib/FileSystem.jar" sourcepath="/opt/ghidra11/Ghidra/Framework/FileSystem/lib/FileSystem-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Framework-AsyncComm/lib/protobuf-java-3.21.8.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Framework-AsyncComm/lib/Framework-AsyncComm.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/Framework-AsyncComm/lib/Framework-AsyncComm-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Framework-Debugging/lib/jna-5.4.0.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Framework-Debugging/lib/Framework-Debugging.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/Framework-Debugging/lib/Framework-Debugging-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Framework-Debugging/lib/jna-platform-5.4.0.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/Framework-TraceModeling/lib/Framework-TraceModeling.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/Framework-TraceModeling/lib/Framework-TraceModeling-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/FunctionGraph/lib/FunctionGraph.jar" sourcepath="/opt/ghidra11/Ghidra/Features/FunctionGraph/lib/FunctionGraph-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/FunctionGraphDecompilerExtension/lib/FunctionGraphDecompilerExtension.jar" sourcepath="/opt/ghidra11/Ghidra/Features/FunctionGraphDecompilerExtension/lib/FunctionGraphDecompilerExtension-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/FunctionID/lib/FunctionID.jar" sourcepath="/opt/ghidra11/Ghidra/Features/FunctionID/lib/FunctionID-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Generic/lib/Generic.jar" sourcepath="/opt/ghidra11/Ghidra/Framework/Generic/lib/Generic-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Generic/lib/commons-compress-1.21.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Generic/lib/log4j-api-2.17.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Generic/lib/failureaccess-1.0.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Generic/lib/bcpkix-jdk15on-1.69.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Generic/lib/log4j-core-2.17.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Generic/lib/guava-32.1.3-jre.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Generic/lib/commons-io-2.11.0.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Generic/lib/jdom-legacy-1.1.3.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Generic/lib/commons-lang3-3.12.0.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Generic/lib/commons-text-1.10.0.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Generic/lib/bcutil-jdk15on-1.69.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Generic/lib/bcprov-jdk15on-1.69.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Generic/lib/commons-collections4-4.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Generic/lib/gson-2.9.0.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/GhidraGo/lib/GhidraGo.jar" sourcepath="/opt/ghidra11/Ghidra/Features/GhidraGo/lib/GhidraGo-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/GhidraServer/lib/GhidraServer.jar" sourcepath="/opt/ghidra11/Ghidra/Features/GhidraServer/lib/GhidraServer-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/GnuDemangler/lib/GnuDemangler.jar" sourcepath="/opt/ghidra11/Ghidra/Features/GnuDemangler/lib/GnuDemangler-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Graph/lib/jgrapht-io-1.5.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Graph/lib/jgrapht-core-1.5.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Graph/lib/jung-visualization-2.1.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Graph/lib/jung-graph-impl-2.1.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Graph/lib/Graph.jar" sourcepath="/opt/ghidra11/Ghidra/Framework/Graph/lib/Graph-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Graph/lib/jung-algorithms-2.1.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Graph/lib/jung-api-2.1.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/GraphFunctionCalls/lib/GraphFunctionCalls.jar" sourcepath="/opt/ghidra11/Ghidra/Features/GraphFunctionCalls/lib/GraphFunctionCalls-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/GraphServices/lib/jgrapht-io-1.5.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/GraphServices/lib/jgrapht-core-1.5.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/GraphServices/lib/jheaps-0.13.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/GraphServices/lib/jungrapht-layout-1.4.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/GraphServices/lib/GraphServices.jar" sourcepath="/opt/ghidra11/Ghidra/Features/GraphServices/lib/GraphServices-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/GraphServices/lib/jungrapht-visualization-1.4.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Gui/lib/flatlaf-3.2.1.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Gui/lib/Gui.jar" sourcepath="/opt/ghidra11/Ghidra/Framework/Gui/lib/Gui-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/HCS12/lib/HCS12.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/HCS12/lib/HCS12-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Help/lib/timingframework-1.0.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Help/lib/javahelp-2.0.05.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Help/lib/Help.jar" sourcepath="/opt/ghidra11/Ghidra/Framework/Help/lib/Help-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/JVM/lib/JVM.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/JVM/lib/JVM-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/Loongarch/lib/Loongarch.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/Loongarch/lib/Loongarch-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/MIPS/lib/MIPS.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/MIPS/lib/MIPS-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/MicrosoftCodeAnalyzer/lib/MicrosoftCodeAnalyzer.jar" sourcepath="/opt/ghidra11/Ghidra/Features/MicrosoftCodeAnalyzer/lib/MicrosoftCodeAnalyzer-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/MicrosoftDemangler/lib/MicrosoftDemangler.jar" sourcepath="/opt/ghidra11/Ghidra/Features/MicrosoftDemangler/lib/MicrosoftDemangler-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/MicrosoftDmang/lib/MicrosoftDmang.jar" sourcepath="/opt/ghidra11/Ghidra/Features/MicrosoftDmang/lib/MicrosoftDmang-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/PDB/lib/PDB.jar" sourcepath="/opt/ghidra11/Ghidra/Features/PDB/lib/PDB-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/PIC/lib/PIC.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/PIC/lib/PIC-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/PowerPC/lib/PowerPC.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/PowerPC/lib/PowerPC-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/ProgramDiff/lib/ProgramDiff.jar" sourcepath="/opt/ghidra11/Ghidra/Features/ProgramDiff/lib/ProgramDiff-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/ProgramGraph/lib/ProgramGraph.jar" sourcepath="/opt/ghidra11/Ghidra/Features/ProgramGraph/lib/ProgramGraph-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Project/lib/xz-1.9.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Project/lib/Project.jar" sourcepath="/opt/ghidra11/Ghidra/Framework/Project/lib/Project-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/ProposedUtils/lib/ProposedUtils.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/ProposedUtils/lib/ProposedUtils-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Pty/lib/jsch-0.1.55.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Pty/lib/Pty.jar" sourcepath="/opt/ghidra11/Ghidra/Framework/Pty/lib/Pty-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Configurations/Public_Release/lib/Public_Release.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/Python/lib/jython-standalone-2.7.3.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/Python/lib/Python.jar" sourcepath="/opt/ghidra11/Ghidra/Features/Python/lib/Python-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/RISCV/lib/RISCV.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/RISCV/lib/RISCV-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/Recognizers/lib/Recognizers.jar" sourcepath="/opt/ghidra11/Ghidra/Features/Recognizers/lib/Recognizers-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/Sarif/lib/java-sarif-2.1-modified.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/Sarif/lib/Sarif.jar" sourcepath="/opt/ghidra11/Ghidra/Features/Sarif/lib/Sarif-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/SoftwareModeling/lib/antlr-runtime-3.5.2.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/SoftwareModeling/lib/relaxngDatatype-20050913.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/SoftwareModeling/lib/msv-20050913.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/SoftwareModeling/lib/xsdlib-20050913.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/SoftwareModeling/lib/isorelax-20050913.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/SoftwareModeling/lib/SoftwareModeling.jar" sourcepath="/opt/ghidra11/Ghidra/Framework/SoftwareModeling/lib/SoftwareModeling-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/SourceCodeLookup/lib/SourceCodeLookup.jar" sourcepath="/opt/ghidra11/Ghidra/Features/SourceCodeLookup/lib/SourceCodeLookup-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/Sparc/lib/Sparc.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/Sparc/lib/Sparc-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/SuperH4/lib/SuperH4.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/SuperH4/lib/SuperH4-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/SystemEmulation/lib/SystemEmulation.jar" sourcepath="/opt/ghidra11/Ghidra/Features/SystemEmulation/lib/SystemEmulation-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Debug/TaintAnalysis/lib/TaintAnalysis.jar" sourcepath="/opt/ghidra11/Ghidra/Debug/TaintAnalysis/lib/TaintAnalysis-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Framework/Utility/lib/Utility.jar" sourcepath="/opt/ghidra11/Ghidra/Framework/Utility/lib/Utility-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/V850/lib/V850.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/VersionTracking/lib/VersionTracking.jar" sourcepath="/opt/ghidra11/Ghidra/Features/VersionTracking/lib/VersionTracking-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Features/VersionTrackingBSim/lib/VersionTrackingBSim.jar" sourcepath="/opt/ghidra11/Ghidra/Features/VersionTrackingBSim/lib/VersionTrackingBSim-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/Xtensa/lib/Xtensa.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/Xtensa/lib/Xtensa-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/eBPF/lib/eBPF.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/eBPF/lib/eBPF-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/tricore/lib/tricore.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/tricore/lib/tricore-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/opt/ghidra11/Ghidra/Processors/x86/lib/x86.jar" sourcepath="/opt/ghidra11/Ghidra/Processors/x86/lib/x86-src.zip">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:/opt/ghidra11/docs/GhidraAPI_javadoc.zip!/api/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="bin"/>

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # Ignore bin folder
 /bin
+
+# Ignore output folder
+/dist

--- a/.project
+++ b/.project
@@ -18,7 +18,7 @@
 		<link>
 			<name>Ghidra</name>
 			<type>2</type>
-			<location>D:/Tools/Ghidra/ghidra_10.2.2_PUBLIC</location>
+			<location>/opt/ghidra11</location>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ These are the basic steps to debug and build the loader. You must have a Ghidra 
 3. In Eclipse, install the Ghidra Development Extension. Click Help > "Install New Software" (https://stackoverflow.com/questions/31553376/eclipse-how-to-install-a-plugin-manually)
 4. After the extension is installed, clone/download this repository, which contains an Eclipse project.
 5. Open the project with Eclipse (File > Open Projects from File System)
-6. Build: Select "File > Export", and then choose "Ghidra > Ghidra Module Extension". You can then use a local Gradle installation or an online build system.
+6. You may need to reconnect Ghidra to the project by right clicking the project in Eclipse, and doing GhidraDev -> Link Ghidra...
+7. Build: Select "File > Export", and then choose "Ghidra > Ghidra Module Extension". You can then use a local Gradle installation or an online build system.
 
 # Acknowledgements
 * Special thanks to [gbatek](https://problemkaputt.de/gbatek.htm) for ds technical info

--- a/src/main/help/help/topics/ntrghidra/help.html
+++ b/src/main/help/help/topics/ntrghidra/help.html
@@ -10,7 +10,7 @@
     <META name="ProgId" content="FrontPage.Editor.Document">
 
     <TITLE>Skeleton Help File for a Module</TITLE>
-    <LINK rel="stylesheet" type="text/css" href="../../shared/Frontpage.css">
+    <LINK rel="stylesheet" type="text/css" href="help/shared/DefaultStyle.css">
   </HEAD>
 
   <BODY>


### PR DESCRIPTION
A TON of library changes from the last version, but seemingly nothing within the code itself. Exported just fine, and I tested it with an NDS rom I had started on earlier. I also made some changes to the readme

A few notes:
- The `.project` file seems like it will need to be edited by every single person who checks this out in hopes of maintaining it. Is there some way around this? The same applies to a few of the `.classpath` records, as some of them just swapped `D:/Tools/Ghidra/ghidra_10.2.2_PUBLIC` for `/opt/ghidra11`, both of which are fairly specific to operating system and filesystem layout
- I added a helpful note to the build steps in the `README.md` that had confused me for a bit. Without the linking step, it appears you simply have hundreds of broken libraries pointing to nowhere, that I had actually started updating manually. I don't wish that mistake on anyone else
- I implemented the fix to the HTML help listed in a previous version (#19), as the issue persisted in 11