### PR TITLE
Added overlay manager. Cleaned up code a bit.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 .settings/
 
 .idea/
+out/

--- a/src/main/java/ntrghidra/NDS.java
+++ b/src/main/java/ntrghidra/NDS.java
@@ -174,7 +174,7 @@ public class NDS
 						Compressed = (0x000000FF & (int)msb & 0x1)==1;
 						AuthenticationCode = (0x000000FF & (int)msb & 0x2)==1;
 					}
-					public boolean getCompressed() {return Compressed;}
+					public boolean isCompressed() {return Compressed;}
 					public boolean getAuthenticationCode() {return AuthenticationCode;}
 				}
 				

--- a/src/main/java/ntrghidra/NTRGhidraLoader.java
+++ b/src/main/java/ntrghidra/NTRGhidraLoader.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,38 +15,37 @@
  */
 
 /*
-* NTRGhidraLoader.java
-* Main plugin file and entrypoint code. 
-*
-* Pedro Javier Fernández
-* 12/06/2022 (DD/MM/YYYY)
-*
-* See project license file for license information.
-*/ 
+ * NTRGhidraLoader.java
+ * Main plugin file and entrypoint code.
+ *
+ * Pedro Javier Fernández
+ * 12/06/2022 (DD/MM/YYYY)
+ *
+ * See project license file for license information.
+ */
 
 package ntrghidra;
 
-// Java standard utilities
-
 import docking.widgets.OptionDialog;
+import ghidra.app.util.MemoryBlockUtils;
 import ghidra.app.util.bin.BinaryReader;
 import ghidra.app.util.bin.ByteProvider;
-import ghidra.app.util.importer.MessageLog;
 import ghidra.app.util.opinion.AbstractLibrarySupportLoader;
 import ghidra.app.util.opinion.LoadSpec;
 import ghidra.program.flatapi.FlatProgramAPI;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.address.AddressOverflowException;
+import ghidra.program.model.lang.CompilerSpecID;
 import ghidra.program.model.lang.LanguageCompilerSpecPair;
 import ghidra.program.model.listing.Program;
-import ghidra.program.model.mem.Memory;
 import ghidra.program.model.mem.MemoryBlock;
 import ghidra.util.exception.CancelledException;
-import ghidra.util.task.TaskMonitor;
 import ntrghidra.NDS.RomOVT;
 import ntrghidra.NDSLabelList.NDSLabel;
 import ntrghidra.NDSMemRegionList.NDSMemRegion;
 import org.apache.commons.compress.utils.Lists;
+import org.apache.commons.lang3.StringUtils;
+import org.bouncycastle.util.Arrays;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -54,264 +53,400 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
 
-import static ghidra.app.util.MemoryBlockUtils.createInitializedBlock;
-
 /**
  * Main entrypoint class
  */
 public class NTRGhidraLoader extends AbstractLibrarySupportLoader {
 
-	private static final String versionStr = "v1.4.4.2";
-	private boolean chosenCPU;
+	public static final String EXECTUABLE_FORMAT = "Nintendo DS (NTR) and DSi (TWL)";
+	public static final String LANGUAGE_ID_ARM7 = "ARM:LE:32:v4t";
+	public static final String LANGUAGE_ID_ARM9 = "ARM:LE:32:v5t";
+
+	private static final String versionStr = "v1.5.0";
+
+	private boolean isARM7;
 	private boolean usesNintendoSDK;
-	
+
 	@Override
 	public String getName() {
-		return "Nintendo DS (NTR) and DSi (TWL)";
+		return NTRGhidraLoader.EXECTUABLE_FORMAT;
 	}
 
 	protected boolean promptToAskCPU() {
-
-		String message = "<html>You have loaded what looks like a Nintendo DS program. <br><br> Nintendo DS binaries contain code for the two CPUs:<br> ARM7 code: Usually handles audio, touch screen, cryptography, etc. <br> ARM9 code: Runs game code, graphics, etc. <br><br> NTRGhidra version " + versionStr + " can work with both.<br>Which one would you like to load? \"";
+		String message = "<html>" +
+						 "You have loaded what looks like a Nintendo DS program." +
+						 " <br><br>" +
+						 " Nintendo DS binaries contain code for the two CPUs:<br>" +
+						 " ARM7 code: Usually handles audio, touch screen, cryptography, etc. <br>" +
+						 " ARM9 code: Runs game code, graphics, etc." +
+						 " <br><br>" +
+						 " NTRGhidra version " + NTRGhidraLoader.versionStr + " can work with both.<br>" +
+						 "Which one would you like to load? \"";
 		//@formatter:off
-			int choice =
-					OptionDialog.showOptionNoCancelDialog(
-					null,
-					"Choose CPU",
-					message,
-					"<html> <font color=\"red\">ARM7</font>",
-					"<html> <font color=\"green\">ARM9</font>",
-					OptionDialog.QUESTION_MESSAGE);
+		int choice = OptionDialog.showOptionNoCancelDialog(
+                null,
+				"Choose CPU",
+				message,
+				"<html> <font color=\"red\">ARM7</font>",
+				"<html> <font color=\"green\">ARM9</font>",
+				OptionDialog.QUESTION_MESSAGE
+        );
 		//@formatter:on
 
-		if (choice == OptionDialog.OPTION_TWO) { // ARM9
-			//chosenCPU = false;
-			return false;
-		}
+		//chosenCPU = false;
+		// ARM9
+		return choice != OptionDialog.OPTION_TWO;
 		//chosenCPU = true;
-		return true; //ARM7
+		//ARM7
 	}
-	
-	protected boolean promptToAskSDK() {
 
-		String message = "<html>Nintendo DS binaries from official games use a known SDK compression algorithm. <br><br> If you are loading a commercial game, click YES. \"";
+	protected boolean promptToAskSDK() {
+		String message = "<html>" +
+						 "Nintendo DS binaries from official games use a known SDK compression algorithm." +
+						 " <br><br>" +
+						 " If you are loading a commercial game, click YES. \"";
 		//@formatter:off
-			int choice =
-					OptionDialog.showOptionNoCancelDialog(
-					null,
-					"Commercial ROM or Homebrew?",
-					message,
-					"<html> <font color=\"red\">NO</font>",
-					"<html> <font color=\"green\">YES</font>",
-					OptionDialog.QUESTION_MESSAGE);
+        int choice = OptionDialog.showOptionNoCancelDialog(
+                null,
+                "Commercial ROM or Homebrew?",
+                message,
+                "<html> <font color=\"red\">NO</font>",
+                "<html> <font color=\"green\">YES</font>",
+                OptionDialog.QUESTION_MESSAGE
+            );
 		//@formatter:on
 
-        return choice == OptionDialog.OPTION_TWO;
-    }
+		return choice == OptionDialog.OPTION_TWO;
+	}
 
-    @Override
-    public Collection<LoadSpec> findSupportedLoadSpecs(ByteProvider provider) throws IOException {
-        // In this callback loader should decide whether it able to process the file and return instance of the class LoadSpec,
-        // telling user how file can be processed
+	@Override
+	public Collection<LoadSpec> findSupportedLoadSpecs(final ByteProvider provider) throws IOException {
+		// In this callback loader should decide whether it able to process the file and return instance of the class LoadSpec,
+		// telling user how file can be processed
 
-        BinaryReader reader = new BinaryReader(provider, true);
+		BinaryReader reader = new BinaryReader(provider, true);
 
-        //Nintendo logo CRC
-        int crcLogo = reader.readUnsignedShort(0x15C);
-        this.usesNintendoSDK = promptToAskSDK();
-        if (usesNintendoSDK) {//If commercial game, ensure logo CRC. Otherwise, we don't care.
-            if (crcLogo != 0xCF56) {
-                return Lists.newArrayList();
-            }
-        }
+		//Nintendo logo CRC
+		int crcLogo = reader.readUnsignedShort(0x15C);
+		this.usesNintendoSDK = promptToAskSDK();
+		if (usesNintendoSDK) {//If commercial game, ensure logo CRC. Otherwise, we don't care.
+			if (crcLogo != 0xCF56) {
+				return Lists.newArrayList();
+			}
+		}
 
-        //Nintendo DS has two CPUs. Ask the user which code he/she wants to work with, the ARM7 one or the ARM9 one.
-        this.chosenCPU = promptToAskCPU();
+		//Nintendo DS has two CPUs. Ask the user which code he/she wants to work with, the ARM7 one or the ARM9 one.
+		this.isARM7 = promptToAskCPU();
 
-        //Setup Ghidra with the chosen CPU.
-        if(chosenCPU)
-            return List.of(new LoadSpec(this, 0, new LanguageCompilerSpecPair("ARM:LE:32:v4t", "default"), true));
-
-        return List.of(new LoadSpec(this, 0, new LanguageCompilerSpecPair("ARM:LE:32:v5t", "default"), true));
-    }
+		//Setup Ghidra with the chosen CPU.
+		if (isARM7) {
+			return List.of(
+					new LoadSpec(this, 0, new LanguageCompilerSpecPair(NTRGhidraLoader.LANGUAGE_ID_ARM7, CompilerSpecID.DEFAULT_ID), true)
+			);
+		}
+		return List.of(
+				new LoadSpec(this, 0, new LanguageCompilerSpecPair(NTRGhidraLoader.LANGUAGE_ID_ARM9, CompilerSpecID.DEFAULT_ID), true)
+		);
+	}
 
 	//https://pedro-javierf.github.io/devblog/advancedghidraloader/
-	void loadARM9Overlays(ByteProvider provider, Program program, NDS romparser, MessageLog log, FlatProgramAPI fpa, TaskMonitor monitor) throws IOException, AddressOverflowException{
-		BinaryReader reader = new BinaryReader(provider, true);
-		
-		int i = 0;
-		for(RomOVT overlay: romparser.getMainOVT())
-		{
-			if(overlay.Flag.getCompressed())
-			{
-				
+	void loadARM9Overlays(final Program program, final ImporterSettings importerSettings, final NDS romparser, final FlatProgramAPI fpa) throws IOException, AddressOverflowException {
+		BinaryReader reader = new BinaryReader(importerSettings.provider(), true);
+
+		RomOVT[] ovt = romparser.getMainOVT();
+		String[] overlayNames = NTRGhidraLoader.generateOverlayNames(romparser, false);
+		OverlaySelectionDialog overlaySelectionDialog = new OverlaySelectionDialog("Select which ARM9 overlays to enable", overlayNames, true);
+		boolean[] isOverlayEnabled = overlaySelectionDialog
+				.show(null);
+
+		for(int i = 0; i < ovt.length; i++) {
+			RomOVT overlay = ovt[i];
+			int fatAddr = romparser.Header.FatOffset + (8 * overlay.FileId);
+
+			InputStream stream;
+			if (overlay.Flag.isCompressed()) {
 				//Compute size of the overlay file
-				int fatAddr = romparser.Header.FatOffset + (8 * overlay.FileId);
 				int fileStart = reader.readInt(fatAddr);
-				int fileEnd = reader.readInt(fatAddr+4);
-				int size = fileEnd-fileStart;
+				int fileEnd = reader.readInt(fatAddr + 4);
+				int size = fileEnd - fileStart;
 
 				//Read the whole (compressed) overlay file
-				InputStream stream = provider.getInputStream(fileStart);
+				stream = importerSettings.provider().getInputStream(fileStart);
 				byte[] Compressed = stream.readNBytes(size);
-				
+
 				//Decompress
 				byte[] Decompressed = romparser.GetDecompressedOverlay(Compressed);
-				
-				createInitializedBlock(program, true, "overlay_d_"+i, fpa.toAddr(overlay.RamAddress), new ByteArrayInputStream(Decompressed), overlay.RamSize, "", "", true, true, true, log, monitor);
+				stream = new ByteArrayInputStream(Decompressed);
+			} else {
+				stream = importerSettings.provider().getInputStream(reader.readInt(fatAddr));
 			}
-			else
-			{
-				int fatAddr = romparser.Header.FatOffset + (8 * overlay.FileId);
-				InputStream stream = provider.getInputStream(reader.readInt(fatAddr));
-				createInitializedBlock(program, true, "overlay_"+i, fpa.toAddr(overlay.RamAddress), stream, overlay.RamSize, "", "", true, true, true, log, monitor);
+
+			if (isOverlayEnabled[i]) {
+				MemoryBlockUtils.createInitializedBlock(
+						program,
+						true,
+						overlayNames[i],
+						fpa.toAddr(overlay.RamAddress),
+						stream,
+						overlay.RamSize,
+						"",
+						"",
+						true,
+						true,
+						true,
+						importerSettings.log(),
+						importerSettings.monitor()
+				);
+			} else {
+				MemoryBlockUtils.createUninitializedBlock(
+						program,
+						true,
+						overlayNames[i],
+						fpa.toAddr(overlay.RamAddress),
+						overlay.RamSize,
+						"",
+						"",
+						true,
+						true,
+						true,
+						importerSettings.log()
+				);
 			}
-			i++;
 		}
 	}
-	
+
 	//ARM7 has support for overlays as well, even compressed, but they have never been used in comercial games.
-	void loadARM7Overlays(ByteProvider provider, Program program, NDS romparser, MessageLog log, FlatProgramAPI fpa, TaskMonitor monitor) throws IOException, AddressOverflowException{
-		BinaryReader reader = new BinaryReader(provider, true);
-		
-		int i = 0;
-		i = 0;
-		for(RomOVT overlay: romparser.getSubOVT())
-		{
-				int fatAddr = romparser.Header.FatOffset + (8 * overlay.FileId);
-				System.out.println("FATADDR: "+fatAddr);
-				InputStream stream = provider.getInputStream(reader.readInt(fatAddr));
-				createInitializedBlock(program, true, "suboverlay_"+i+"_"+overlay.Id, fpa.toAddr(overlay.RamAddress), stream, overlay.RamSize, "", "", true, true, true, log, monitor);
-				i++;
+	void loadARM7Overlays(final ImporterSettings importerSettings, final Program program, final NDS romparser, final FlatProgramAPI fpa) throws IOException, AddressOverflowException {
+		BinaryReader reader = new BinaryReader(importerSettings.provider(), true);
+
+		RomOVT[] subOVT = romparser.getSubOVT();
+		String[] suboverlayNames = NTRGhidraLoader.generateOverlayNames(romparser, true);
+		OverlaySelectionDialog subOverlaySelectionDialog = new OverlaySelectionDialog("Select which ARM7 suboverlays to enable", suboverlayNames, true);
+		boolean[] isSubOverlayEnabled = subOverlaySelectionDialog
+				.show(null);
+
+		for(int i = 0; i < subOVT.length; i++) {
+			final RomOVT overlay = subOVT[i];
+			int fatAddr = romparser.Header.FatOffset + (8 * overlay.FileId);
+
+			System.out.println("FATADDR: " + fatAddr);
+			importerSettings.log().appendMsg("FATADDR: " + fatAddr);
+
+			InputStream stream = importerSettings.provider().getInputStream(reader.readInt(fatAddr));
+			if (isSubOverlayEnabled[i]) {
+				MemoryBlockUtils.createInitializedBlock(
+						program,
+						true,
+						suboverlayNames[i],
+						fpa.toAddr(overlay.RamAddress),
+						stream,
+						overlay.RamSize,
+						"",
+						"",
+						true,
+						true,
+						true,
+						importerSettings.log(),
+						importerSettings.monitor()
+				);
+			} else {
+				MemoryBlockUtils.createUninitializedBlock(
+						program,
+						true,
+						suboverlayNames[i],
+						fpa.toAddr(overlay.RamAddress),
+						overlay.RamSize,
+						"",
+						"",
+						true,
+						true,
+						true,
+						importerSettings.log()
+				);
+			}
 		}
 	}
 
-    @SuppressWarnings("resource")
-    @Override
-	protected void load(final Program program, final ImporterSettings importerSettings) throws CancelledException, IOException
-	{
+	@SuppressWarnings("resource")
+	@Override
+	protected void load(final Program program, final ImporterSettings importerSettings) throws CancelledException, IOException {
 		FlatProgramAPI api = new FlatProgramAPI(program, importerSettings.monitor());
-		Memory mem = program.getMemory();
 
-        importerSettings.monitor().setMessage("Loading Nintendo DS (NTR) binary...");
-		
+		importerSettings.monitor().setMessage("Loading Nintendo DS (NTR) binary...");
+
 		//Handles the NDS format in detail
 		NDS romParser = new NDS(importerSettings.provider());
-		
-		try
-		{
-			if(!chosenCPU) //ARM9
-			{
-                importerSettings.monitor().setMessage("Loading Nintendo DS ARM9 binary...");
-				
-				//Read the important values from the header. 
+		try {
+			if (!isARM7) {//ARM9
+				importerSettings.monitor().setMessage("Loading Nintendo DS ARM9 binary...");
+
+				//Read the important values from the header.
 				int arm9_file_offset = romParser.Header.MainRomOffset;
 				int arm9_entrypoint = romParser.Header.MainEntryAddress;
 				int arm9_ram_base = romParser.Header.MainRamAddress;
 				int arm9_size = romParser.Header.MainSize;
-				
-				if(usesNintendoSDK) //try to apply decompression
-				{
+
+				if (usesNintendoSDK) {//try to apply decompression
 					//Get decompressed blob
-					byte decompressedBytes[] = romParser.GetDecompressedARM9();
-					
+					byte[] decompressedBytes = romParser.GetDecompressedARM9();
+
 					/// Main RAM block: has to be created without the Flat API.
 					Address addr = program.getAddressFactory().getDefaultAddressSpace().getAddress(arm9_ram_base);
-					MemoryBlock block = mem.createInitializedBlock("ARM9_Main_Memory", addr, decompressedBytes.length, (byte)0x00, importerSettings.monitor(), false);
-					
+					MemoryBlock block = program.getMemory().createInitializedBlock(
+							"ARM9_Main_Memory",
+							addr,
+							decompressedBytes.length,
+							(byte) 0x00,
+							importerSettings.monitor(),
+							false
+					);
+
 					//Set properties
 					block.setRead(true);
 					block.setWrite(true);
 					block.setExecute(true);
-					
+
 					//Fill the main memory segment with the decompressed data/code.
-					mem.setBytes(api.toAddr(arm9_ram_base), decompressedBytes);
-				}
-				else
-				{
+					program.getMemory().setBytes(api.toAddr(arm9_ram_base), decompressedBytes);
+				} else {
 					//read arm9 blob
-					byte romBytes[] = importerSettings.provider().readBytes(arm9_file_offset, arm9_size);
-					
+					byte[] romBytes = importerSettings.provider().readBytes(arm9_file_offset, arm9_size);
+
 					/// Main RAM block: has to be created without the Flat API.
 					Address addr = program.getAddressFactory().getDefaultAddressSpace().getAddress(arm9_ram_base);
-					MemoryBlock block = mem.createInitializedBlock("ARM9_Main_Memory", addr, arm9_size, (byte)0x00, importerSettings.monitor(), false);
-					
+					MemoryBlock block = program.getMemory().createInitializedBlock(
+							"ARM9_Main_Memory",
+							addr,
+							arm9_size,
+							(byte) 0x00,
+							importerSettings.monitor(),
+							false
+					);
+
 					//Set properties
 					block.setRead(true);
 					block.setWrite(true);
 					block.setExecute(true);
-					
+
 					//Fill the main memory segment with the data from the binary directly
-					mem.setBytes(api.toAddr(arm9_ram_base), romBytes);
+					program.getMemory().setBytes(api.toAddr(arm9_ram_base), romBytes);
 				}
-					
+
 				//Uninitialized memory regions
-				for(NDSMemRegion r: NDSMemRegionList.getInstance().getARM9Regions())
-				{
+				for(NDSMemRegion r : NDSMemRegionList.getInstance().getARM9Regions()) {
 					api.createMemoryBlock(r.name(), api.toAddr(r.addr()), null, r.size(), true);
 				}
-				
+
 				//Labels (REGISTERS, others, etc.)
-				for(NDSLabel l: NDSLabelList.getInstance().getARM9Labels())
-				{
-					api.createLabel(api.toAddr(l.addr()),l.name(),true);
+				for(NDSLabel l : NDSLabelList.getInstance().getARM9Labels()) {
+					api.createLabel(api.toAddr(l.addr()), l.name(), true);
 				}
-				
+
 				//Load overlays (segments of memory that are usually loaded at the same address/regions)
-				loadARM9Overlays(importerSettings.provider(),program, romParser, importerSettings.log(), api, importerSettings.monitor());
-				
+				loadARM9Overlays(
+						program,
+						importerSettings,
+						romParser,
+						api
+				);
+
 				//Set entrypoint
 				api.addEntryPoint(api.toAddr(arm9_entrypoint));
 				api.disassemble(api.toAddr(arm9_entrypoint));
 				api.createFunction(api.toAddr(arm9_entrypoint), "_entry_arm9");
-			}
-			else //ARM7
-			{
-                importerSettings.monitor().setMessage("Loading Nintendo DS ARM7 binary...");
+			} else {//ARM7
+				importerSettings.monitor().setMessage("Loading Nintendo DS ARM7 binary...");
 				int arm7_file_offset = romParser.Header.SubRomOffset;
 				int arm7_entrypoint = romParser.Header.SubEntryAddress;
 				int arm7_ram_base = romParser.Header.SubRamAddress;
 				int arm7_size = romParser.Header.SubSize;
-				
+
 				//Create ARM7 Memory Map
 				Address addr = program.getAddressFactory().getDefaultAddressSpace().getAddress(arm7_ram_base);
-				MemoryBlock block = program.getMemory().createInitializedBlock("ARM7_Main_Memory", addr, arm7_size, (byte)0x00, importerSettings.monitor(), false);
-				
+				MemoryBlock block = program.getMemory()
+						.createInitializedBlock(
+								"ARM7_Main_Memory",
+								addr,
+								arm7_size,
+								(byte) 0x00,
+								importerSettings.monitor(),
+								false
+						);
+
 				//Set properties
 				block.setRead(true);
 				block.setWrite(true);
 				block.setExecute(true);
-				
+
 				//Fill with the actual contents from file
-                //noinspection resource
-                byte romBytes[] = importerSettings.provider().readBytes(arm7_file_offset, arm7_size);
+				//noinspection resource
+				byte[] romBytes = importerSettings.provider().readBytes(arm7_file_offset, arm7_size);
 				program.getMemory().setBytes(addr, romBytes);
-				
+
 				//Uninitialized memory regions
-				for(NDSMemRegion r: NDSMemRegionList.getInstance().getARM7Regions())
-				{
+				for(NDSMemRegion r : NDSMemRegionList.getInstance().getARM7Regions()) {
 					api.createMemoryBlock(r.name(), api.toAddr(r.addr()), null, r.size(), true);
 				}
-				
+
 				//Labels (REGISTERS, others, etc.)
-				for(NDSLabel l: NDSLabelList.getInstance().getARM7Labels())
-				{
-					api.createLabel(api.toAddr(l.addr()),l.name(),true);
+				for(NDSLabel l : NDSLabelList.getInstance().getARM7Labels()) {
+					api.createLabel(api.toAddr(l.addr()), l.name(), true);
 				}
-				
+
 				//Load overlays (segments of memory that are usually loaded at the same address/regions)
-				loadARM7Overlays(importerSettings.provider(),program, romParser, importerSettings.log(), api, importerSettings.monitor());
-				
+				loadARM7Overlays(
+						importerSettings,
+						program,
+						romParser,
+						api
+				);
+
 				//Set entrypoint
 				api.addEntryPoint(api.toAddr(arm7_entrypoint));
 				api.disassemble(api.toAddr(arm7_entrypoint));
 				api.createFunction(api.toAddr(arm7_entrypoint), "_entry_arm7");
-			}	
-		}
-		catch (Exception e) {
+			}
+		} catch (Exception e) {
 			e.printStackTrace();
-            importerSettings.log().appendException(e);
+			importerSettings.log().appendException(e);
 		}
+	}
+
+	public static String[] generateOverlayNames(final NDS nds, final boolean isARM7) {
+		return NTRGhidraLoader.generateOverlayNames(nds, isARM7, true);
+	}
+
+	/**
+	 * @param nds
+	 * @param isARM7
+	 * @param shouldLeftPad If the overlay index should be leftpadded.</br>Leftpadded: 000</br>Non-leftpadded: 0
+	 * @return
+	 */
+	public static String[] generateOverlayNames(final NDS nds, final boolean isARM7, final boolean shouldLeftPad) {
+		RomOVT[] overlays = isARM7 ? nds.getSubOVT() : nds.getMainOVT();
+		if (Arrays.isNullOrEmpty(overlays)) return new String[0];
+		int overlayCharLen = String.valueOf(overlays.length).length();
+		String[] names = new String[overlays.length];
+		for(int i = 0; i < overlays.length; i++) {
+			RomOVT overlay = overlays[i];
+			StringBuilder nameBuilder = new StringBuilder();
+			if (isARM7) {
+				nameBuilder.append("suboverlay_");
+			} else {
+				nameBuilder.append("overlay_");
+			}
+			if (!isARM7 && overlay.Flag.isCompressed()) nameBuilder.append("d_");
+			if (shouldLeftPad) {
+				nameBuilder.append(
+						StringUtils.leftPad(String.valueOf(i), overlayCharLen, '0')
+				);
+			} else {
+				nameBuilder.append(i);
+			}
+			if (isARM7) nameBuilder.append('_').append(overlay.Id);
+			names[i] = nameBuilder.toString();
+		}
+		return names;
 	}
 
 }

--- a/src/main/java/ntrghidra/OverlaySelectionDialog.java
+++ b/src/main/java/ntrghidra/OverlaySelectionDialog.java
@@ -1,0 +1,248 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ntrghidra;
+
+import docking.DialogComponentProvider;
+import docking.DockingWindowManager;
+import docking.widgets.checkbox.GCheckBox;
+import docking.widgets.label.GDLabel;
+import docking.widgets.label.GHtmlLabel;
+
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.Icon;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+
+/**
+ * Modeled after {@link docking.widgets.dialogs.InputWithChoicesDialog}<br/>
+ *
+ * Created by Master on 2/19/2026 at 2:40 PM
+ *
+ * @author Master
+ */
+public class OverlaySelectionDialog extends DialogComponentProvider {
+
+	private final String[] items;
+	private final List<GCheckBox> checkBoxes = new ArrayList<>();
+
+	private JScrollPane scrollPaneCheckBoxes;
+	private boolean isCanceled = false;
+
+	public OverlaySelectionDialog(final String title, final String[] items, final boolean addButtons) {
+		this(title, items, null, addButtons);
+	}
+
+	public OverlaySelectionDialog(final String title, final String[] items, final Icon messageIcon, final boolean addButtons) {
+		super(title, true, false, true, false);
+		super.setTransient(true);
+
+		if (addButtons) {
+			super.addOKButton();
+			super.addCancelButton();
+		}
+
+		super.setRememberSize(false);
+		super.setRememberLocation(false);
+
+		this.items = items;
+		buildMainPanel(title, this.items, messageIcon);
+		super.setFocusComponent(scrollPaneCheckBoxes);
+	}
+
+	@Override
+	protected void okCallback() {
+		super.okCallback();
+		isCanceled = false;
+		super.close();
+	}
+
+	@Override
+	protected void cancelCallback() {
+		isCanceled = true;
+		super.cancelCallback();
+	}
+
+	private JScrollPane createCheckboxPanel(final String[] items) {
+		JPanel panel = new JPanel();
+		panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+		if (items != null) {
+			for(final String item : items) {
+				GCheckBox checkBox = new GCheckBox(item);
+				checkBox.setSelected(true);//enable by default
+				checkBoxes.add(checkBox);
+				panel.add(checkBox);
+			}
+		}
+		JScrollPane scrollPane = new JScrollPane(panel);
+		scrollPane.setPreferredSize(new Dimension(200, 250));
+		return scrollPane;
+	}
+
+	private JPanel createButtonsPanel() {
+		JPanel buttonsPanel = new JPanel(new BorderLayout());
+		buttonsPanel.getAccessibleContext().setAccessibleName("Buttons");
+
+		JButton buttonSelectAll = new JButton("Select All");
+		buttonSelectAll.getAccessibleContext().setAccessibleName("SelectAll");
+		buttonSelectAll.addActionListener(e -> checkBoxes.forEach(checkBox -> checkBox.setSelected(true)));
+
+		JButton buttonSelectNone = new JButton("Select None");
+		buttonSelectNone.getAccessibleContext().setAccessibleName("SelectNone");
+		buttonSelectNone.addActionListener(e -> checkBoxes.forEach(checkBox -> checkBox.setSelected(false)));
+
+		buttonsPanel.add(buttonSelectAll, BorderLayout.WEST);
+		buttonsPanel.add(buttonSelectNone, BorderLayout.EAST);
+		return buttonsPanel;
+	}
+
+	/**
+	 * Stolen and modified from {@link docking.widgets.dialogs.InputWithChoicesDialog#buildMainPanel(String, String[], String, Icon)}
+	 *
+	 * @param labelText
+	 * @param items
+	 * @param messageIcon
+	 */
+	@SuppressWarnings("JavadocReference")
+	private void buildMainPanel(final String labelText, final String[] items, final Icon messageIcon) {
+		JPanel workPanel = new JPanel(new BorderLayout());
+		workPanel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+
+		JLabel messageLabel = new GHtmlLabel(labelText);
+		messageLabel.setBorder(BorderFactory.createEmptyBorder(0, 0, 5, 0));
+		messageLabel.getAccessibleContext().setAccessibleName("Message");
+
+		scrollPaneCheckBoxes = createCheckboxPanel(items);
+		scrollPaneCheckBoxes.getAccessibleContext().setAccessibleName("Checkboxes");
+
+		JPanel dataPanel = new JPanel(new BorderLayout());
+		dataPanel.add(messageLabel, BorderLayout.NORTH);
+		dataPanel.add(scrollPaneCheckBoxes, BorderLayout.CENTER);
+		dataPanel.getAccessibleContext().setAccessibleName("Data");
+
+		JPanel buttonsPanel = createButtonsPanel();
+		buttonsPanel.setBorder(BorderFactory.createEmptyBorder(10, 0, 0, 0));
+		dataPanel.add(buttonsPanel, BorderLayout.SOUTH);
+
+		workPanel.add(dataPanel, BorderLayout.CENTER);
+
+		if (messageIcon != null) {
+			JLabel iconLabel = new GDLabel();
+			iconLabel.setIcon(messageIcon);
+			iconLabel.setVerticalAlignment(1);
+			iconLabel.getAccessibleContext().setAccessibleName("Icon");
+			JPanel separatorPanel = new JPanel();
+			separatorPanel.setPreferredSize(new Dimension(15, 1));
+			separatorPanel.getAccessibleContext().setAccessibleName("Separator");
+			JPanel iconPanel = new JPanel(new BorderLayout());
+			iconPanel.add(iconLabel, BorderLayout.CENTER);
+			iconPanel.add(separatorPanel, BorderLayout.EAST);
+			iconPanel.getAccessibleContext().setAccessibleName("Icon");
+			workPanel.add(iconPanel, BorderLayout.WEST);
+		}
+
+		workPanel.getAccessibleContext().setAccessibleName("Overlay Selection");
+		super.addWorkPanel(workPanel);
+	}
+
+	public boolean[] show(final Component parent) {
+		DockingWindowManager.showDialog(parent, this);
+		return getSelected();
+	}
+
+	public boolean isCanceled() {
+		return isCanceled;
+	}
+
+	public boolean[] getSelected() {
+		boolean[] isOverlayEnabled = new boolean[checkBoxes.size()];
+		if (isCanceled()) {
+			Arrays.fill(isOverlayEnabled, true);
+			return isOverlayEnabled;
+		}
+		for(int i = 0; i < checkBoxes.size(); i++) isOverlayEnabled[i] = checkBoxes.get(i).isSelected();
+		return isOverlayEnabled;
+	}
+
+	public void setSelected(final boolean[] selected) {
+		if ((selected == null || selected.length == 0) || selected.length != checkBoxes.size()) return;
+		IntStream.range(0, selected.length).forEachOrdered(i -> checkBoxes.get(i).setSelected(selected[i]));
+	}
+
+	/**
+	 * For testing
+	 */
+	public static void main(final String[] args) {
+		SwingUtilities.invokeLater(() -> {
+			JFrame frame = new JFrame("Hello World");
+			frame.setLayout(new BorderLayout());
+			frame.setSize(300, 500);
+
+			OverlaySelectionDialog overlaySelectionDialog = new OverlaySelectionDialog(
+					"Stuff",
+					new String[] {
+							"overlay_1",
+							"overlay_2",
+							"overlay_3",
+							"overlay_4",
+							"overlay_5",
+							"overlay_6",
+							"overlay_7",
+							"overlay_8",
+							"overlay_9",
+							"overlay_10",
+							"overlay_11",
+							"overlay_12",
+							"overlay_13",
+							"overlay_14",
+							"overlay_15",
+							"overlay_16",
+							"overlay_17",
+							"overlay_18",
+							"overlay_19",
+							"overlay_20",
+							"overlay_21",
+							"overlay_22",
+							"overlay_23",
+							"overlay_24",
+							"overlay_25",
+					},
+					true
+			);
+			frame.add(
+					overlaySelectionDialog.createCheckboxPanel(overlaySelectionDialog.items),
+					BorderLayout.CENTER
+			);
+			frame.validate();
+
+			frame.setDefaultCloseOperation(JDialog.EXIT_ON_CLOSE);
+			frame.setVisible(true);
+		});
+	}
+
+}

--- a/src/main/java/ntrghidra/plugin/InitializeOverlayCmd.java
+++ b/src/main/java/ntrghidra/plugin/InitializeOverlayCmd.java
@@ -1,0 +1,121 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ntrghidra.plugin;
+
+import ghidra.app.plugin.core.memory.UninitializedBlockCmd;
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.ByteProvider;
+import ghidra.app.util.opinion.Loader.ImporterSettings;
+import ghidra.framework.cmd.BackgroundCommand;
+import ghidra.program.flatapi.FlatProgramAPI;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.MemoryBlock;
+import ghidra.util.Msg;
+import ghidra.util.exception.RollbackException;
+import ghidra.util.task.TaskMonitor;
+import ntrghidra.NDS;
+import ntrghidra.NDS.RomOVT;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * {@link UninitializedBlockCmd}
+ *
+ * Created by Master on 3/2/2026 at 5:32 PM
+ *
+ * @author Master
+ */
+public class InitializeOverlayCmd extends BackgroundCommand<Program> {
+
+	private final Program program;
+	private final MemoryBlock memoryBlock;
+
+	private final NDS nds;
+	private final RomOVT overlay;
+	private final ByteProvider byteProvider;
+
+	public InitializeOverlayCmd(final Program program, final MemoryBlock memoryBlock, final NDS nds, final RomOVT overlay, final ByteProvider byteProvider) {
+		super("Initialize Overlay", false, true, true);
+		this.program = program;
+		this.memoryBlock = memoryBlock;
+		this.nds = nds;
+		this.overlay = overlay;
+		this.byteProvider = byteProvider;
+	}
+
+	/**
+	 * {@link ntrghidra.NTRGhidraLoader#loadARM7Overlays(ImporterSettings, Program, NDS, FlatProgramAPI)}
+	 * {@link ntrghidra.NTRGhidraLoader#loadARM9Overlays(Program, ImporterSettings, NDS, FlatProgramAPI)}
+	 */
+	@SuppressWarnings("JavadocReference")
+	@Override
+	public boolean applyTo(final Program obj, final TaskMonitor monitor) {
+		if (monitor.isCancelled()) throw new RollbackException("Operation cancelled");
+		int fatAddr = nds.Header.FatOffset + (8 * overlay.FileId);
+		BinaryReader binaryReader = new BinaryReader(byteProvider, true);
+
+		//Decompression stuff
+		//Stolen from NTRGhidraLoader
+		InputStream stream;
+		try {
+			if (overlay.Flag.isCompressed()) {
+				//Compute size of the overlay file
+				int fileStart = binaryReader.readInt(fatAddr);
+				int fileEnd = binaryReader.readInt(fatAddr + 4);
+				int size = fileEnd - fileStart;
+
+				//Read the whole (compressed) overlay file
+				stream = byteProvider.getInputStream(fileStart);
+				byte[] Compressed = stream.readNBytes(size);
+
+				//Decompress
+				byte[] Decompressed = nds.GetDecompressedOverlay(Compressed);
+				stream = new ByteArrayInputStream(Decompressed);
+			} else {
+				stream = byteProvider.getInputStream(binaryReader.readInt(fatAddr));
+			}
+		} catch(IOException e) {
+			Msg.error(this, "Failed to load overlay!", e);
+			setStatusMsg(e.getMessage());
+			return false;
+		}
+
+		//MemoryMapModel#initializeBlock(Memoryblock)
+		int transactionID = program.startTransaction("Initialize Overlay");
+		try {
+			byte[] memBlockData = stream.readNBytes(overlay.RamSize);
+			program.getMemory().convertToInitialized(memoryBlock, (byte)0x00);
+			program.getMemory().setBytes(memoryBlock.getStart(), memBlockData);//Unsafe! This can allow under or overflowing data to be set!
+			program.endTransaction(transactionID, true);
+			Msg.debug(this, String.format("Initialized overlay \"%s\"", memoryBlock.getName()));
+		} catch(Throwable e) {
+			program.endTransaction(transactionID, false);
+			Msg.showError(
+					this,
+					null,
+					NTRGhidraPlugin.NAME,
+					String.format("Failed to initialize overlay \"%s\"!", memoryBlock.getName()),
+					e
+			);
+			setStatusMsg(e.getMessage());
+			return false;
+		}
+		return true;
+	}
+
+}

--- a/src/main/java/ntrghidra/plugin/NTRGhidraComponentProvider.java
+++ b/src/main/java/ntrghidra/plugin/NTRGhidraComponentProvider.java
@@ -1,0 +1,228 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ntrghidra.plugin;
+
+import docking.ActionContext;
+import docking.DialogComponentProvider;
+import docking.WindowPosition;
+import docking.action.DockingAction;
+import docking.action.KeyBindingType;
+import docking.action.ToolBarData;
+import docking.widgets.OptionDialog;
+import ghidra.app.plugin.core.memory.UninitializedBlockCmd;
+import ghidra.app.util.bin.ByteProvider;
+import ghidra.formats.gfilesystem.FSRL;
+import ghidra.framework.cmd.BackgroundCommand;
+import ghidra.framework.plugintool.ComponentProviderAdapter;
+import ghidra.framework.plugintool.PluginTool;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.MemoryBlock;
+import ghidra.util.Msg;
+import ntrghidra.NDS;
+import ntrghidra.NDS.RomOVT;
+import ntrghidra.OverlaySelectionDialog;
+
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
+import java.io.File;
+import java.io.IOException;
+import java.util.stream.IntStream;
+
+/**
+ * Created by Master on 2/28/2026 at 6:03 PM
+ *
+ * @author Master
+ */
+@SuppressWarnings("FieldCanBeLocal")
+public class NTRGhidraComponentProvider extends ComponentProviderAdapter {
+
+	/**
+	 * <b>WARNING:</b></br>
+	 * This is <b>NOT</b> thread-safe!</br>
+	 * Be <b>VERY</b> careful when and where to use this!
+	 */
+	private final Program program;
+	/**
+	 * <b>WARNING:</b></br>
+	 * This is <b>NOT</b> thread-safe!</br>
+	 * Be <b>VERY</b> careful when and where to use this!
+	 */
+	private final NDS nds;
+	/**
+	 * <b>WARNING:</b></br>
+	 * This is <b>NOT</b> thread-safe!</br>
+	 * Be <b>VERY</b> careful when and where to use this!
+	 */
+	private final File fileROM;
+	/**
+	 * <b>WARNING:</b></br>
+	 * This is <b>NOT</b> thread-safe!</br>
+	 * Be <b>VERY</b> careful when and where to use this!
+	 */
+	private final FSRL fsrlROM;
+
+	private final boolean isARM7;
+	private final String[] items;
+
+	private JPanel mainPanel;
+	private JButton buttonOk, buttonCancel;
+
+	private DockingAction dockingAction;
+	private OverlaySelectionDialog overlaySelectionDialog;
+
+	public NTRGhidraComponentProvider(final PluginTool tool, final String owner, final Program program, final NDS nds, final File fileROM, final FSRL fsrlROM, final boolean isARM7, final String[] items) {
+		super(tool, NTRGhidraPlugin.NAME, owner);
+		super.setIcon(NTRGhidraPlugin.getIcon());
+		super.setDefaultWindowPosition(WindowPosition.WINDOW);
+		super.setTitle(NTRGhidraPlugin.NAME);
+
+		this.program = program;
+		this.nds = nds;
+		this.fileROM = fileROM;
+		this.fsrlROM = fsrlROM;
+
+		this.isARM7 = isARM7;
+		this.items = items;
+
+		buildButtons();
+		buildMainPanel(isARM7, this.items);
+		createActions(isARM7);
+	}
+
+	@Override
+	public JComponent getComponent() {
+		return mainPanel;
+	}
+
+	/**
+	 * Stolen from:</br>
+	 * {@link DialogComponentProvider#addOKButton()}</br>
+	 * {@link DialogComponentProvider#addCancelButton()}
+	 */
+	@SuppressWarnings("JavadocReference")
+	private void buildButtons() {
+		buttonOk = new JButton("OK");
+		buttonOk.setMnemonic('K');
+		buttonOk.setName("OK");
+		buttonOk.getAccessibleContext().setAccessibleName("OK");
+		buttonOk.addActionListener(this::callbackButtonOK);
+
+		buttonCancel = new JButton("Cancel");
+		buttonCancel.setMnemonic('C');
+		buttonCancel.setName("Cancel");
+		buttonCancel.getAccessibleContext().setAccessibleName("Cancel");
+		buttonCancel.addActionListener(this::callbackButtonCancel);
+	}
+
+	private void buildMainPanel(final boolean isARM7, final String[] items) {
+		mainPanel = new JPanel(new BorderLayout());
+		overlaySelectionDialog = new OverlaySelectionDialog(
+				isARM7 ? "ARM7 Overlays" : "ARM9 Overlays",
+				items,
+				isARM7 ? NTRGhidraPlugin.getIconARM7() : NTRGhidraPlugin.getIconARM9(),
+				false
+		);
+		overlaySelectionDialog.getComponent().setPreferredSize(new Dimension(250, 300));
+		boolean[] selectedOverlays = new boolean[items.length];
+		IntStream.range(0, items.length).forEachOrdered(i -> {//Populate with current overlays
+			MemoryBlock memoryBlock = program.getMemory().getBlock(items[i]);
+			if (memoryBlock == null) {
+				Msg.warn(this, String.format("Memory block \"%s\" does not exist?!", items[i]));
+				return;
+			}
+			selectedOverlays[i] = memoryBlock.isInitialized();
+		});
+		overlaySelectionDialog.setSelected(selectedOverlays);
+		mainPanel.add(overlaySelectionDialog.getComponent(), BorderLayout.CENTER);
+
+		//Stolen from DialogComponentProvider
+		JPanel panelButtons = new JPanel(new GridLayout(1, 0, 50, 0));
+		panelButtons.add(buttonOk);
+		panelButtons.add(buttonCancel);
+		JPanel panel = new JPanel(new FlowLayout());
+		panel.setBorder(BorderFactory.createEmptyBorder(0, 0, 10, 0));
+		panel.add(panelButtons);
+		mainPanel.add(panel, BorderLayout.SOUTH);
+	}
+
+	private void createActions(final boolean isARM7) {
+		dockingAction = new DockingAction(NTRGhidraPlugin.NAME, super.getOwner(), KeyBindingType.UNSUPPORTED) {//TODO Add keybinding?
+
+			@Override
+			public void actionPerformed(final ActionContext actionContext) {
+				//NOOP
+			}
+
+		};
+		if (program != null) {
+			super.setVisible(true);
+			dockingAction.setEnabled(true);
+		} else {
+			Msg.error(this, "Could not add NTRGhidra's overlay manager to the menu bar due to no program!");
+			dockingAction.setEnabled(false);
+		}
+		dockingAction.setToolBarData(new ToolBarData(isARM7 ? NTRGhidraPlugin.getIconARM7() : NTRGhidraPlugin.getIconARM9()));
+		dockingAction.setDescription(NTRGhidraPlugin.NAME);
+		super.addLocalAction(dockingAction);
+	}
+
+	private void callbackButtonOK(final ActionEvent actionEvent) {
+		int option = OptionDialog.showYesNoDialogWithNoAsDefaultButton(null, "Confirm overlay change","Are you really sure?");
+		if (option == OptionDialog.YES_OPTION) {
+			try(ByteProvider byteProvider = NTRGhidraPlugin.loadNDSFile(fileROM, fsrlROM, true)) {
+				if (byteProvider == null) {
+					Msg.showError(this, null, NTRGhidraPlugin.NAME, "Failed to load NDS file?!");
+					return;
+				}
+				final boolean[] selectedOverlay = overlaySelectionDialog.getSelected();
+				for(int i = 0; i < items.length; i++) {
+					final String overlayName = items[i];
+					final MemoryBlock memoryBlock = program.getMemory().getBlock(overlayName);
+					if (memoryBlock == null) {
+						Msg.warn(NTRGhidraComponentProvider.class, String.format("Missing memory block \"%s\"?!", overlayName));
+						continue;
+					}
+
+					//Keeps heavy processing from using the Swing UI thread
+					BackgroundCommand<Program> cmd = null;
+					if (!memoryBlock.isInitialized() && selectedOverlay[i]) {
+						RomOVT overlay = isARM7 ? nds.getSubOVT()[i] : nds.getMainOVT()[i];
+						cmd = new InitializeOverlayCmd(program, memoryBlock, nds, overlay, byteProvider);
+					} else if (memoryBlock.isInitialized() && !selectedOverlay[i]) {//MemoryMapModel#revertBlockToUninitialized(MemoryBlock)
+						cmd = new UninitializedBlockCmd(memoryBlock);
+					}
+					if (cmd != null) super.getTool().executeBackgroundCommand(cmd, program);
+				}
+			} catch (IOException e) {
+				Msg.error(this, "Failed to load NDS file?!", e);
+				return;
+			}
+			super.closeComponent();
+		}
+	}
+
+	private void callbackButtonCancel(final ActionEvent actionEvent) {
+		super.closeComponent();
+	}
+
+}

--- a/src/main/java/ntrghidra/plugin/NTRGhidraPlugin.java
+++ b/src/main/java/ntrghidra/plugin/NTRGhidraPlugin.java
@@ -1,0 +1,270 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ntrghidra.plugin;
+
+import docking.widgets.OptionDialog;
+import docking.widgets.OptionDialogBuilder;
+import docking.widgets.filechooser.GhidraFileChooser;
+import generic.hash.HashUtilities;
+import ghidra.MiscellaneousPluginPackage;
+import ghidra.app.events.ProgramActivatedPluginEvent;
+import ghidra.app.plugin.GenericPluginCategoryNames;
+import ghidra.app.plugin.ProgramPlugin;
+import ghidra.app.util.bin.ByteArrayProvider;
+import ghidra.app.util.bin.ByteProvider;
+import ghidra.app.util.bin.FileByteProvider;
+import ghidra.formats.gfilesystem.FSRL;
+import ghidra.formats.gfilesystem.FileSystemService;
+import ghidra.framework.plugintool.PluginInfo;
+import ghidra.framework.plugintool.PluginTool;
+import ghidra.framework.plugintool.util.PluginStatus;
+import ghidra.framework.store.LockException;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.MemoryBlock;
+import ghidra.util.MD5Utilities;
+import ghidra.util.Msg;
+import ghidra.util.Swing;
+import ghidra.util.filechooser.GhidraFileChooserModel;
+import ghidra.util.filechooser.GhidraFileFilter;
+import ntrghidra.NDS;
+import ntrghidra.NTRGhidraLoader;
+import resources.Icons;
+
+import javax.swing.Icon;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.AccessMode;
+import java.util.Arrays;
+
+/**
+ * Created by Master on 2/28/2026 at 4:32 PM
+ *
+ * @author Master
+ */
+@PluginInfo(
+		status = PluginStatus.STABLE,
+		packageName = MiscellaneousPluginPackage.NAME,
+		category = GenericPluginCategoryNames.MISC,
+		description = NTRGhidraPlugin.NAME,
+		shortDescription = NTRGhidraPlugin.NAME,
+		eventsConsumed = {
+				ProgramActivatedPluginEvent.class
+		}
+)
+public class NTRGhidraPlugin extends ProgramPlugin {
+
+	public static final String NAME = "NTRGhidra Overlay Manager";
+
+	private static final byte[] BYTES_CRC_NINTENDO_LOGO = new byte[] {//Nintendo CRC16 is 0xCF56 - this is in reverse due to how the Java I/O works
+			(byte)0x56,
+			(byte)0xCF
+	};
+
+	private static Icon icon;
+	private static Icon iconARM7, iconARM9;
+
+	private File fileROM;
+	private FSRL fsrlROM;
+	private NDS nds;
+
+	private NTRGhidraComponentProvider componentProvider;
+
+	public NTRGhidraPlugin(final PluginTool plugintool) {
+		super(plugintool);
+		NTRGhidraPlugin.icon = Icons.get("NTRGhidra.png");
+		NTRGhidraPlugin.iconARM7 = Icons.get("ARM7.png", 128, 128);
+		NTRGhidraPlugin.iconARM9 = Icons.get("ARM9.png", 128, 128);
+	}
+
+	@Override
+	protected void programActivated(final Program program) {
+		super.programActivated(program);
+		if (!program.getExecutableFormat().equals(NTRGhidraLoader.EXECTUABLE_FORMAT)) {
+			Msg.info(this, "Not an NTRGhidra program. Disabling...");
+			return;
+		}
+
+		Msg.debug(this, "Initializing plugin...");
+
+		boolean isARM7 = program.getLanguageID().getIdAsString().equals(NTRGhidraLoader.LANGUAGE_ID_ARM7);
+		boolean isARM9 = program.getLanguageID().getIdAsString().equals(NTRGhidraLoader.LANGUAGE_ID_ARM9);
+		if (!isARM7 && !isARM9) {
+			Msg.info(this, "Program is not ARM7 or ARM9?! Disabling...");
+			return;
+		}
+
+		fileROM = new File(program.getExecutablePath());
+		if (!fileROM.exists()) {
+			//Run dialog only on the Swing thread
+			Swing.runNow(() -> {
+				OptionDialogBuilder optionDialogBuilder = new OptionDialogBuilder();
+				optionDialogBuilder.setTitle(NTRGhidraPlugin.NAME);
+				optionDialogBuilder.setMessage(
+						"Could not find original ROM file!\n" +
+						"Would you like to manually look for it?"
+				);
+				optionDialogBuilder.setMessageType(OptionDialog.QUESTION_MESSAGE);
+				optionDialogBuilder.addOption("Yes");
+				optionDialogBuilder.addCancel();
+
+				OptionDialog optionDialog = optionDialogBuilder.build();
+				int option = optionDialog.show();
+				if (option == OptionDialog.YES_OPTION) {
+					GhidraFileChooser fileChooser = new GhidraFileChooser(optionDialog.getComponent());
+					fileChooser.setFileFilter((new GhidraFileFilter() {
+
+						@Override
+						public boolean accept(final File file, final GhidraFileChooserModel ghidraFileChooserModel) {
+							return file.exists() && (
+									file.isDirectory() || (file.isFile() && file.getName().toLowerCase().endsWith(".nds"))
+							);
+						}
+
+						@Override
+						public String getDescription() {
+							return "*.nds Files";
+						}
+
+					}));
+
+					final File fileChosen = fileChooser.getSelectedFile(true);
+					if (fileChosen != null) fileROM = fileChosen;
+				}
+			});
+		}
+
+		if ((fileROM != null && fileROM.exists()) && !program.getExecutablePath().equals(FileSystemService.getInstance().getLocalFSRL(fileROM).getPath())) {
+			String md5;
+			try {
+				md5 = MD5Utilities.getMD5Hash(fileROM);
+				String sha256 = HashUtilities.getHash(HashUtilities.SHA256_ALGORITHM, fileROM);
+				Msg.debug(this, String.format("Caculated MD5 hash %s for substitute file \"%s\"", md5, fileROM.getAbsolutePath()));
+				Msg.debug(this, String.format("Caculated SHA256 hash %s for substitute file \"%s\"", sha256, fileROM.getAbsolutePath()));
+				if (!program.getExecutableMD5().equals(md5) || !program.getExecutableSHA256().equals(sha256)) {
+					Msg.showError(this, null, NTRGhidraPlugin.NAME, "The selected substitute file does not match the program's original file!\nNTRGhidra's Overlay Manager will be disabled");
+					Msg.debug(this, String.format("Expected MD5: %s", program.getExecutableMD5()));
+					Msg.debug(this, String.format("Expected SHA256: %s", program.getExecutableSHA256()));
+					return;
+				}
+			} catch(final IOException e) {
+				Msg.error(this, "Failed to calculate substitute file checksums?!", e);
+				return;
+			}
+			fsrlROM = FileSystemService.getInstance().getLocalFSRL(fileROM).withMD5(md5);
+		}
+
+		//Attempt to get FSRL from the program
+		//This should only ever happen if the FSRL was not substituted by a different file
+		if (fsrlROM == null) fsrlROM = FSRL.fromProgram(program);
+		if (fsrlROM == null) {
+			Msg.error(this, "Failed to get FSRL?!");
+			return;
+		}
+
+		try(ByteProvider byteProvider = NTRGhidraPlugin.loadNDSFile(fileROM, fsrlROM, true)) {
+			try {
+				nds = new NDS(byteProvider);
+			} catch (IOException e) {
+				Msg.error(this, "Failed to load NDS due to I/O exception!", e);
+				return;
+			}
+		} catch(IOException e) {
+			Msg.error(this, "Failed to load NDS file due to I/O exception!", e);
+			return;
+		}
+
+		String[] overlayNames = NTRGhidraLoader.generateOverlayNames(nds, isARM7, false);//Get non-leftpadded name first in case an older program is loaded
+		if (overlayNames.length > 0) {
+			String[] overlayNamesOld = Arrays.copyOf(overlayNames, overlayNames.length);//Copy the old names over so we can rename them
+			overlayNames = NTRGhidraLoader.generateOverlayNames(nds, isARM7);//Set new leftpadded names
+
+			//Checks if overlay names are old
+			for(int i = 0; i < overlayNamesOld.length; i++) {
+				MemoryBlock memoryBlockOld = program.getMemory().getBlock(overlayNamesOld[i]);//Memory block has old non-leftpadded name
+				if (memoryBlockOld != null) {//Migrate over to new names
+					Msg.debug(this, String.format("Found old overlay name \"%s\"", memoryBlockOld.getName()));
+
+					String overlayNameNew = overlayNames[i];//We can reuse the same index because both name lists are sorted in the same order
+					if (program.getMemory().getBlock(overlayNameNew) != null) {//Skip block if it exists in both
+						Msg.debug(this, "Overlay exists in both. Skipping");
+						continue;
+					}
+
+					int transactionID = program.startTransaction("Migrating overlay name...");
+					try {
+						memoryBlockOld.setName(overlayNameNew);
+					} catch (LockException e) {
+						Msg.error(this, String.format("Failed to migrate old overlay name from \"%s\" to \"%s\"!", overlayNamesOld[i], overlayNameNew), e);
+						program.endTransaction(transactionID, false);
+						continue;
+					}
+					program.endTransaction(transactionID, true);
+
+					Msg.debug(this, String.format("Migrated overlay to new name \"%s\"", overlayNameNew));
+				}
+			}
+		}
+		componentProvider = new NTRGhidraComponentProvider(super.getTool(), super.getName(), program, nds, fileROM, fsrlROM, isARM7, overlayNames);
+
+		Msg.debug(this, "Done initializing plugin");
+	}
+
+	@Override
+	protected void dispose() {
+		super.dispose();
+		if (fileROM != null) fileROM = null;
+		if (fsrlROM != null) fsrlROM = null;
+		if (nds != null) nds = null;
+		if (componentProvider != null) componentProvider.setVisible(false);
+	}
+
+	public static ByteProvider loadNDSFile(final File fileROM, final FSRL fsrlROM, final boolean checkCRC) throws IOException {
+		if (fileROM == null) {
+			Msg.error(NTRGhidraPlugin.class, "ROM file is null!?");
+			return null;
+		}
+		if (fsrlROM == null) {
+			Msg.error(NTRGhidraPlugin.class, "FSRL for ROM is null!?");
+			return null;
+		}
+		try(FileByteProvider fbp = new FileByteProvider(fileROM, fsrlROM, AccessMode.READ)) {
+			final byte[] fileData = fbp.readBytes(0, fbp.length());
+			try(ByteArrayProvider byteArrayProvider = new ByteArrayProvider(fileData)) {
+				if (checkCRC) {
+					final byte[] readCRC = byteArrayProvider.readBytes(0x15C, 2);
+					if (!Arrays.equals(readCRC, NTRGhidraPlugin.BYTES_CRC_NINTENDO_LOGO)) {//Assume only commercial uses overlays?
+						Msg.warn(NTRGhidraPlugin.class, "Bad Nintendo CRC check!");
+						return null;
+					}
+				}
+				return byteArrayProvider;
+			}
+		}
+	}
+
+	public static Icon getIcon() {
+		return NTRGhidraPlugin.icon;
+	}
+
+	public static Icon getIconARM7() {
+		return NTRGhidraPlugin.iconARM7;
+	}
+
+	public static Icon getIconARM9() {
+		return NTRGhidraPlugin.iconARM9;
+	}
+
+}


### PR DESCRIPTION
- Added overlay manager plugin
- Code was cleaned up a bit

Closes issue https://github.com/pedro-javierf/NTRGhidra/issues/29

~~Warning: This **MAY** (or rather, *will*) break overlay names in previously created Ghidra projects, as this PR completely changes the way overlay names are created. (Overlay numbers are now left-padded so they sort sequentially in Ghidra's Memory Manager.)~~

EDIT: I've pushed a new commit that will migrate old overlay names over to the new standard. However, it will only happen if the plugin is enabled.

The original `.nds` file **MUST** be in the exact same location as when it was imported into Ghidra, otherwise you will get a file prompt to look for it every load (this can be mitigated by simply disabling the NTRGhidra Overlay Manager plugin after.)

The NTRGhidra Overlay Manager plugin **must** be enabled before using, by toggling it in the `Configure` -> `Miscellaneous` menu, in the `Decompiler` tool.
<img width="1920" height="1040" alt="ntrghidra7" src="https://github.com/user-attachments/assets/4c2d57a1-9cb7-4f5d-a51b-ed150f32dfd7" />

After enabling, the NTRGhidra Overlay Manager can be shown by selecting it under the menu item `Window` -> `NTRGhidra Overlay Manager`.
<img width="1920" height="1040" alt="ntrghidra3" src="https://github.com/user-attachments/assets/271e8fce-03ed-418c-bb2f-e203db7b2dbf" />
<img width="1920" height="1040" alt="ntrghidra4" src="https://github.com/user-attachments/assets/55582629-0c19-4751-8026-1a5b470d7ec6" />
